### PR TITLE
Rename `CloudScraperHttpGateway` to `DefaultHttpGateway`

### DIFF
--- a/novelsave_sources/sources/crawler.py
+++ b/novelsave_sources/sources/crawler.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup, Comment
 from requests.cookies import RequestsCookieJar
 
 from ..exceptions import BadResponseException
-from ..utils.http import BaseHttpGateway, CloudScraperHttpGateway
+from ..utils.http import BaseHttpGateway, DefaultHttpGateway
 
 
 class Crawler(ABC):
@@ -18,7 +18,7 @@ class Crawler(ABC):
     rejected: str
 
     def __init__(self, http_gateway: BaseHttpGateway = None):
-        self.http_gateway = http_gateway if http_gateway is not None else CloudScraperHttpGateway()
+        self.http_gateway = http_gateway if http_gateway is not None else DefaultHttpGateway()
 
     def set_cookies(self, cookies: RequestsCookieJar):
         self.http_gateway.cookies = cookies

--- a/novelsave_sources/utils/http.py
+++ b/novelsave_sources/utils/http.py
@@ -35,7 +35,7 @@ class BaseHttpGateway(ABC):
         """Replace the existing cookies of the client with the provided"""
 
 
-class CloudScraperHttpGateway(BaseHttpGateway):
+class DefaultHttpGateway(BaseHttpGateway):
     """Http gateway implementation that uses cloudscraper module for http requests"""
 
     def __init__(self):


### PR DESCRIPTION
while it still uses cloudscraper, it is heavily modified so it is better to use another name to distinguish them